### PR TITLE
Tile-o-Tiles, #261

### DIFF
--- a/games/Memory Game/memory.py
+++ b/games/Memory Game/memory.py
@@ -1,0 +1,88 @@
+"""Simon Says
+
+Exercises
+
+1. Speed up tile flash rate.
+2. Add more tiles.
+"""
+
+from random import choice
+from time import sleep
+from turtle import *
+
+from freegames import floor, square, vector
+
+pattern = []
+guesses = []
+tiles = {
+    vector(0, 0): ('red', 'dark red'),
+    vector(0, -200): ('blue', 'dark blue'),
+    vector(-200, 0): ('green', 'dark green'),
+    vector(-200, -200): ('yellow', 'khaki'),
+}
+
+
+def grid():
+    """Draw grid of tiles."""
+    square(0, 0, 200, 'dark red')
+    square(0, -200, 200, 'dark blue')
+    square(-200, 0, 200, 'dark green')
+    square(-200, -200, 200, 'khaki')
+    update()
+
+
+def flash(tile):
+    """Flash tile in grid."""
+    glow, dark = tiles[tile]
+    square(tile.x, tile.y, 200, glow)
+    update()
+    sleep(0.5)
+    square(tile.x, tile.y, 200, dark)
+    update()
+    sleep(0.5)
+
+
+def grow():
+    """Grow pattern and flash tiles."""
+    tile = choice(list(tiles))
+    pattern.append(tile)
+
+    for tile in pattern:
+        flash(tile)
+
+    print('Pattern length:', len(pattern))
+    guesses.clear()
+
+
+def tap(x, y):
+    """Respond to screen tap."""
+    onscreenclick(None)
+    x = floor(x, 200)
+    y = floor(y, 200)
+    tile = vector(x, y)
+    index = len(guesses)
+
+    if tile != pattern[index]:
+        exit()
+
+    guesses.append(tile)
+    flash(tile)
+
+    if len(guesses) == len(pattern):
+        grow()
+
+    onscreenclick(tap)
+
+
+def start(x, y):
+    """Start game."""
+    grow()
+    onscreenclick(tap)
+
+
+setup(420, 420, 370, 0)
+hideturtle()
+tracer(False)
+grid()
+onscreenclick(start)
+done()

--- a/games/Memory Game/readme.md
+++ b/games/Memory Game/readme.md
@@ -1,0 +1,1 @@
+Click the screen to start. Watch the pattern and then click the tiles in the same order. Each time you get the sequence right the pattern gets one step longer.

--- a/games/Tile-O-Tiles/readme.md
+++ b/games/Tile-O-Tiles/readme.md
@@ -1,0 +1,1 @@
+puzzle game of sliding numbers into place. Click a tile adjacent to the empty square to swap positions.

--- a/games/Tile-O-Tiles/tile.py
+++ b/games/Tile-O-Tiles/tile.py
@@ -1,0 +1,91 @@
+"""Memory, puzzle game of number pairs.
+
+Exercises:
+
+1. Count and print how many taps occur.
+2. Decrease the number of tiles to a 4x4 grid.
+3. Detect when all tiles are revealed.
+4. Center single-digit tile.
+5. Use letters instead of tiles.
+"""
+
+from random import *
+from turtle import *
+
+from freegames import path
+
+car = path('car.gif')
+tiles = list(range(32)) * 2
+state = {'mark': None}
+hide = [True] * 64
+
+
+def square(x, y):
+    """Draw white square with black outline at (x, y)."""
+    up()
+    goto(x, y)
+    down()
+    color('black', 'white')
+    begin_fill()
+    for count in range(4):
+        forward(50)
+        left(90)
+    end_fill()
+
+
+def index(x, y):
+    """Convert (x, y) coordinates to tiles index."""
+    return int((x + 200) // 50 + ((y + 200) // 50) * 8)
+
+
+def xy(count):
+    """Convert tiles count to (x, y) coordinates."""
+    return (count % 8) * 50 - 200, (count // 8) * 50 - 200
+
+
+def tap(x, y):
+    """Update mark and hidden tiles based on tap."""
+    spot = index(x, y)
+    mark = state['mark']
+
+    if mark is None or mark == spot or tiles[mark] != tiles[spot]:
+        state['mark'] = spot
+    else:
+        hide[spot] = False
+        hide[mark] = False
+        state['mark'] = None
+
+
+def draw():
+    """Draw image and tiles."""
+    clear()
+    goto(0, 0)
+    shape(car)
+    stamp()
+
+    for count in range(64):
+        if hide[count]:
+            x, y = xy(count)
+            square(x, y)
+
+    mark = state['mark']
+
+    if mark is not None and hide[mark]:
+        x, y = xy(mark)
+        up()
+        goto(x + 2, y)
+        color('black')
+        write(tiles[mark], font=('Arial', 30, 'normal'))
+
+    update()
+    ontimer(draw, 100)
+
+
+shuffle(tiles)
+setup(420, 420, 370, 0)
+addshape(car)
+hideturtle()
+tracer(False)
+onscreenclick(tap)
+draw()
+done()


### PR DESCRIPTION
Fixes #261

puzzle game of sliding numbers into place. Click a tile adjacent to the empty square to swap positions.


https://user-images.githubusercontent.com/82095877/169234576-afefe309-5765-4fc0-b2bf-22b0463b6afd.mp4

